### PR TITLE
XWPFPicture: easy access to width and depth

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
@@ -77,6 +77,20 @@ public class XWPFPicture {
         }
         return null;
     }
+   
+    /**
+     * Returns the width of the picture (in EMU). 
+     */
+    public long getWidth() {
+        return ctPic.getSpPr().getXfrm().getExt().getCx();
+    }
+   
+    /**
+     * Returns the width of the picture (in EMU). 
+     */
+    public long getDepth() {
+        return ctPic.getSpPr().getXfrm().getExt().getCy();
+    }
 
     public String getDescription() {
         return description;


### PR DESCRIPTION
I suppose adding a test case wouldn't hurt (something like calling XWPFRun.addPicture then calling these two new methods). 

(BTW, would a pull request to add an overload to XWPFRun.addPicture be accepted? It would be to compute the width and depth from the input file, using javax.ImageIO -- an acceptable dependency or not?)